### PR TITLE
Permalink Generation  - Unused code 

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -245,7 +245,6 @@ function generatePermalink(){
 	if(config.parameters){
 		$.each(config.parameters, function(paramGroupName, paramGroup) {
 			var selectedParamText = $('#'+paramGroupName +" option[value='"+$('#'+paramGroupName).val()+"']").text();
-			var group = $(this).attr("id");
 			href = href + "&" + paramGroupName + "=" + encodeURIComponent(selectedParamText);
 		});
 	}


### PR DESCRIPTION
This unused line of code was causing the dashboard to crash for me, as in some instances the this pointer was a large array of numbers and obviously doing a jquery select on an array of numbers isn't going to go down to well. 
