### PR TITLE
Allow index 0 for dynamic queries

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -364,7 +364,7 @@ function endsWith(str, suffix) {
 function getParamValueFromPath(paramGroup, metric) {
 	var result = "";
 
-	if (paramGroup.index) {
+	if (paramGroup.index != undefined) {
 		var pathParts = metric.path.split(".");
 		result = pathParts[paramGroup.index];
 	} else {


### PR DESCRIPTION
Previous code would just take the metric name instead of the first node. Explicitly checking whether index is defined make sure we really use the intended index when given.
