### PR TITLE
added URI encoding for dynamic query

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -318,7 +318,7 @@ function generateDynamicQuery(paramGroupName) {
 		}
 		query = applyParameter(query, dependsOn, dependValue);
 	}
-	return query;
+	return encodeURIComponent(query);
 }
 
 function renderDynamicParamGroup(paramGroupName, paramGroup) {


### PR DESCRIPTION
Because graphite can't cope with special characters, I URL-encoded my metric names (like my.server.my%20metric). If the dynamic query doesn't get URL encoded, 'my%20metric' comes in as 'my metric' at graphite, which of course will fail.
