### PR TITLE
External dynamic parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ You can then use a target like ```services.prod.${service}.${host}_${datacenter}
 
 Graphitus will also consider generating the list of values from a partial path, the index and regex determine which portion and substring (regex) of the resulting path will be used to generate the values for selection. The ```showAll``` property is used to determine if graphitus will prepend a default All (translated to ```*``` in the graphite query) option to the selection. The ```showAllValue``` parameter can be added to override the default ```*``` selection for complex name filtering schemes (you can have token in this value to express dependencies on other parameters).
 
+* External dynamic parameters
+
+External dynamic parameters allow metric selection and filtering based on a REST API query.
+
+It is configured like dynamic parameters, with the addition of the ```uri``` option to set your REST endpoint, which should output a JSON hash. The ```key``` option is an array that defines the hash key that contains the required data. 
+
+        "environment": {
+            "type":     "extDynamic",
+            "uri":      "http://dashboard/environments",
+            "key":      [ "result", "environments" ],
+            "showAll":  true
+        }
+
 * More info and examples
 
 - [Blog post](http://techo-ecco.com/blog/monitoring-apache-hadoop-cassandra-and-zookeeper-using-graphite-and-jmxtrans)

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -210,6 +210,9 @@ function renderParamToolbar() {
 				dynamicParams[paramGroupName] = paramGroup;
 				loadParameterDependencies(paramGroupName, paramGroup.query);
 				renderDynamicParamGroup(paramGroupName, paramGroup);
+			} else if (paramGroup.type && paramGroup.type == "extDynamic") {
+				dynamicParams[paramGroupName] = paramGroup;
+				renderExtDynamicParamGroup(paramGroupName, paramGroup);
 			} else {
 				renderValueParamGroup(paramGroupName, paramGroup);
 			}
@@ -315,6 +318,33 @@ function generateDynamicQuery(paramGroupName) {
 	}
 	return query;
 }
+
+function renderExtDynamicParamGroup(paramGroupName, paramGroup) {
+	$.getJSON(paramGroup["uri"], function(data){
+		keyname = paramGroup["key"]
+		unpackedData = data[keyname[0]]
+		for (var i=1;i<keyname.length;i++){
+			unpackedData = unpackedData[keyname[i]]
+		}
+		parameters = new Object();
+		if (paramGroup.showAll){
+			parameters["All"] = new Object();
+			parameters["All"][paramGroupName] = new Object();
+			parameters["All"][paramGroupName] = (paramGroup.showAllValue) ? applyParameters(paramGroup.showAllValue) : "*";
+		}
+
+		$.each(unpackedData, function(k,v){
+			servers = "{"+v.join(",")+"}"
+			parameters[k] = {}
+			parameters[k][paramGroupName] = servers
+		})
+		console.log(parameters)
+		config.parameters[paramGroupName] = parameters;
+		renderValueParamGroup(paramGroupName, parameters)
+		updateGraphs()
+	})
+}
+
 
 function renderDynamicParamGroup(paramGroupName, paramGroup) {
 	var url = getGraphiteServer() + "/metrics/find?format=completer&query=";

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -338,7 +338,6 @@ function renderExtDynamicParamGroup(paramGroupName, paramGroup) {
 			parameters[k] = {}
 			parameters[k][paramGroupName] = servers
 		})
-		console.log(parameters)
 		config.parameters[paramGroupName] = parameters;
 		renderValueParamGroup(paramGroupName, parameters)
 		updateGraphs()


### PR DESCRIPTION
Add support for dynamic parameters from an external source

We have a pool of resources that are assigned to projects. This changes reasonably frequently. Relevant metrics we have are recorded at an infrastructure/host level, but needs to be represented per-project.

This patch allows us to leverage existing project-host mappings.
