### PR TITLE
Added default value support for non dynamic parameter groups.

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -260,7 +260,7 @@ function renderValueParamGroup(paramGroupName, paramGroup) {
 	$("#" + paramGroupName).append(_.template(tmplParamSelItem, {
 		group: paramGroupName,
 		params: paramGroup,
-		selected: getDefaultValue(paramGroupName)
+		selected: getDefaultValue(paramGroupName, paramGroup)
 	}));
 	$("#" + paramGroupName).select2({
 		placeholder: "Select a " + paramGroupName,
@@ -273,13 +273,15 @@ function renderValueParamGroup(paramGroupName, paramGroup) {
 	});
 }
 
-function getDefaultValue(paramGroupName) {
+function getDefaultValue(paramGroupName, paramGroup) {
 	if (queryParam(paramGroupName)) {
 		return queryParam(paramGroupName);
 	} else if (dynamicParams[paramGroupName] && dynamicParams[paramGroupName].defaultValue) {
 		return dynamicParams[paramGroupName].defaultValue;
+	} else if (paramGroup && paramGroup.defaultValue) {
+		return paramGroup.defaultValue
 	} else {
-		return "";
+	    return ""
 	}
 }
 


### PR DESCRIPTION
The "defaultValue" property coming from the json defining a dashboard for NON dynamic parameter groups was being ignored when rendering default values, but no longer.
